### PR TITLE
Remove `custom.envVars`, add CORS templates, handle timeouts

### DIFF
--- a/restApi/multi/create/s-function.json
+++ b/restApi/multi/create/s-function.json
@@ -10,7 +10,6 @@
   "authorizer": {},
   "custom": {
     "excludePatterns": [],
-    "envVars": [],
     "optimize": true
   },
   "endpoints": [

--- a/restApi/multi/create/s-function.json
+++ b/restApi/multi/create/s-function.json
@@ -34,6 +34,13 @@
           "application/json": ""
         }
       }
+    },
+    {
+      "path": "multi/create",
+      "method": "OPTIONS",
+      "type": "MOCK",
+      "requestTemplates": "$${apiCorsRequestTemplate}",
+      "responses": "$${apiCorsOptionsResponse}"
     }
   ],
   "events": [],

--- a/restApi/multi/show/s-function.json
+++ b/restApi/multi/show/s-function.json
@@ -34,6 +34,13 @@
           "application/json": ""
         }
       }
+    },
+    {
+      "path": "/show/{id}",
+      "method": "OPTIONS",
+      "type": "MOCK",
+      "requestTemplates": "$${apiCorsRequestTemplate}",
+      "responses": "$${apiCorsOptionsResponse}"
     }
   ],
   "events": [],

--- a/restApi/multi/show/s-function.json
+++ b/restApi/multi/show/s-function.json
@@ -10,7 +10,6 @@
   "authorizer": {},
   "custom": {
     "excludePatterns": [],
-    "envVars": [],
     "optimize": true
   },
   "endpoints": [

--- a/restApi/single/s-function.json
+++ b/restApi/single/s-function.json
@@ -10,7 +10,6 @@
   "authorizer": {},
   "custom": {
     "excludePatterns": [],
-    "envVars": [],
     "optimize": true
   },
   "endpoints": [

--- a/restApi/single/s-function.json
+++ b/restApi/single/s-function.json
@@ -100,6 +100,13 @@
           "application/json": ""
         }
       }
+    },
+    {
+      "path": "single",
+      "method": "OPTIONS",
+      "type": "MOCK",
+      "requestTemplates": "$${apiCorsRequestTemplate}",
+      "responses": "$${apiCorsOptionsResponse}"
     }
   ],
   "events": [],

--- a/s-templates.json
+++ b/s-templates.json
@@ -8,5 +8,45 @@
       "headerParamNames": "$input.params().header.keySet()",
       "contentTypeValue": "$input.params().header.get('Content-Type')"
     }
+  },
+  "apiDefault200Response": {
+    "statusCode": "200",
+    "responseParameters": {
+      "method.response.header.Access-Control-Allow-Origin": "'*'"
+    },
+    "responseModels": {},
+    "responseTemplates": {
+      "application/json": ""
+    }
+  },
+  "api400ErrorMatchResponse": {
+    "statusCode": "400",
+    "selectionPattern": "Task timed out.*",
+    "responseTemplates": {
+      "application/json": ""
+    },
+    "responseParameters": {
+      "method.response.header.Access-Control-Allow-Origin": "'*'"
+    }
+  },
+  "apiCorsOptionsResponse": {
+    "default": {
+      "statusCode": "200",
+      "responseParameters": {
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
+        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,HEAD,DELETE,PATCH,POST,PUT'",
+        "method.response.header.Access-Control-Allow-Origin": "'*'",
+        "method.response.header.Access-Control-Max-Age": "'3600'"
+      },
+      "responseModels": {},
+      "responseTemplates": {
+        "application/json": ""
+      }
+    }
+  },
+  "apiCorsRequestTemplate": {
+    "application/json": {
+      "statusCode": 200
+    }
   }
 }


### PR DESCRIPTION
As far as I can tell, as of v0.5 `custom.envVars` in `s-function.json` is no longer used
